### PR TITLE
Small addition to fulfill two purposes:

### DIFF
--- a/src/main/java/com/lytrax/accessconverter/SQLiteConverter.java
+++ b/src/main/java/com/lytrax/accessconverter/SQLiteConverter.java
@@ -105,6 +105,9 @@ public class SQLiteConverter extends Converter {
         
         for(Column column : table.getColumns()) {
             String name = column.getName();
+                if (name == "Index") {
+                    name = "Idx";
+            }
             String type = column.getType().toString().toUpperCase();
             //short length = column.getLength();
             
@@ -148,6 +151,11 @@ public class SQLiteConverter extends Converter {
                     sql.append(String.format("`%s` VARCHAR(50) DEFAULT '{00000000-0000-0000-0000-000000000000}'", name));
                     break;
                 case "TEXT":
+                    sql.append(String.format("`%s` VARCHAR(255) DEFAULT ''", name));
+                    break;
+                case "OLE":
+                    sql.append(String.format("`%s` BLOB", name));
+                    break;
                 default:
                     sql.append(String.format("`%s` VARCHAR(255) DEFAULT ''", name));
                     break;
@@ -257,6 +265,20 @@ public class SQLiteConverter extends Converter {
                             case "GUID":
                             case "TEXT":
                                 sql.append(String.format("'%s'", row.getString(name).replace("'", "''")));
+                            	break;
+                            case "BINARY":
+                            case "OLE":
+                                byte[] ba = row.getBytes(name);
+                                if (ba.length > 0) {
+                                    final String    HEXES    = "0123456789ABCDEF";
+                                    sql.append("x'");
+                                    for (byte b : ba) {
+                                        sql.append(HEXES.charAt((b & 0xF0) >> 4)).append(HEXES.charAt((b & 0x0F)));
+                                    }
+                                    sql.append("'");
+                                } else {
+                                    sql.append("NULL");
+                                }
                                 break;
                             case "COMPLEX_TYPE":
                             default:


### PR DESCRIPTION
This will do two things:

- rename columns named "Index" to "Idx" ("Index" is an allowed name in MS-Access, but is forbidden in SQLite).
- copy over "OLE" data into BLOBs.

The first is trivial and hopefully unique to my database as (repeatedly) calling a "index" a column when that is a reserved word in SQL is not very smart.
Renaming attempt shouldn't hurt anyways.

The second allows to pass over data contained in OLE columns, in hope someone will be able to interpret them.
In my case those "OLE" fields contain jpeg-formatted images, without any "decoration".
They show up as "UNKNOWN" OLE Type in jackcess.